### PR TITLE
Add end-of-line semicolons for consistency

### DIFF
--- a/src/kata.js
+++ b/src/kata.js
@@ -1,3 +1,3 @@
 function Person() {
-  return { greet: "Hello!" }
+  return { greet: "Hello!" };
 }

--- a/test/kata_spec.js
+++ b/test/kata_spec.js
@@ -1,6 +1,6 @@
 describe("Person", function () {
   it("has a greeting", function() {
-    var person = new Person()
+    var person = new Person();
     expect(person.greet).toBe("Hello!");
-  })
-})
+  });
+});


### PR DESCRIPTION
One line in `test/kata_spec.js` has a semicolon, but the other does not. As far as I can tell, using explicit semicolons is the most common JavaScript style, so I added missing semicolons in the two source files.
