### PR TITLE
Update Makefile to help provide environment for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,12 @@ test:
 	npm test
 
 dependencies:
-	which node npm phantomjs
-	npm install
+	@(which node >/dev/null || echo "make: ***" STOP: node.js not found) || true
+	@(which node >/dev/null || echo "make: ***" node.js must be installed prior to using this kata-seed) || true
+	@(which node >/dev/null || (which brew >/dev/null && echo "make: ***" You can use \`brew install node\' on OS to install node.js)) || true
+	@(which node >/dev/null || (which brew >/dev/null || echo "make: ***" To install on OS, first install homebrew \(http://brew.sh/\) then you can use \`brew install node\')) || true
+	@(which node >/dev/null || echo "make: ***" After installing node, please run \`make\' again) || true
+	@which node >/dev/null && npm install phantomjs
+	@which node >/dev/null && npm install
 
 .PHONY: all dependencies test

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ dependencies:
 	@(which node >/dev/null || (which brew >/dev/null || echo "make: ***" To install on OS, first install homebrew \(http://brew.sh/\) then you can use \`brew install node\')) || true
 	@(which node >/dev/null || echo "make: ***" After installing node, please run \`make\' again) || true
 	which node >/dev/null && npm install phantomjs
-	which node >/dev/null && npm install
+	npm install
 
 .PHONY: all dependencies test

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ dependencies:
 	@(which node >/dev/null || (which brew >/dev/null && echo "make: ***" You can use \`brew install node\' on OS to install node.js)) || true
 	@(which node >/dev/null || (which brew >/dev/null || echo "make: ***" To install on OS, first install homebrew \(http://brew.sh/\) then you can use \`brew install node\')) || true
 	@(which node >/dev/null || echo "make: ***" After installing node, please run \`make\' again) || true
-	@which node >/dev/null && npm install phantomjs
-	@which node >/dev/null && npm install
+	which node >/dev/null && npm install phantomjs
+	which node >/dev/null && npm install
 
 .PHONY: all dependencies test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Determine platform name and perform OS-specific dependency checks
+platform=$(shell uname)
+
 all: dependencies test
 
 test:
@@ -6,10 +9,13 @@ test:
 dependencies:
 	@(which node >/dev/null || echo "make: ***" STOP: node.js not found) || true
 	@(which node >/dev/null || echo "make: ***" node.js must be installed prior to using this kata-seed) || true
-	@(which node >/dev/null || (which brew >/dev/null && echo "make: ***" You can use \`brew install node\' on OS to install node.js)) || true
-	@(which node >/dev/null || (which brew >/dev/null || echo "make: ***" To install on OS, first install homebrew \(http://brew.sh/\) then you can use \`brew install node\')) || true
+
+	@[ '$(platform)' = 'Darwin' ] && (which node >/dev/null || (which brew >/dev/null && echo "make: ***" You can use \`brew install node\' on OSX to install node.js)) || true
+	@[ '$(platform)' = 'Darwin' ] && (which node >/dev/null || (which brew >/dev/null || echo "make: ***" To install on OSX, first install homebrew \(http://brew.sh/\) then you can use \`brew install node\')) || true
+
 	@(which node >/dev/null || echo "make: ***" After installing node, please run \`make\' again) || true
-	which node >/dev/null && npm install phantomjs
+	@which node >/dev/null
+	npm install phantomjs
 	npm install
 
 .PHONY: all dependencies test

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ dependencies:
 	@[ '$(platform)' = 'Darwin' ] && (which node >/dev/null || (which brew >/dev/null || echo "make: ***" To install on OSX, first install homebrew \(http://brew.sh/\) then you can use \`brew install node\')) || true
 
 	@(which node >/dev/null || echo "make: ***" After installing node, please run \`make\' again) || true
-	@which node >/dev/null
+	@which node >/dev/null 	# fail silently if node does not exist (but first present information)
 	npm install phantomjs
 	npm install
 


### PR DESCRIPTION
Fixed installation of the phantomjs dependency that would not install because of a missing operator between two distinct statements. 

Added more logic that would tell the user how to go about installing node and/or homebrew if on OSX.
Also allow for more logic based on platform variable.

This resolves issue #4 - initial setup not working.
